### PR TITLE
More Descriptive 404 link text

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -5,7 +5,7 @@
         <br>
         <i>That’s all I know.</i>
     </p>
-    <a href="." style="text-decoration:underline">Am here.</a>
+    <a href="." style="text-decoration:underline">Take me home.</a>
 {{ end }}
 
 {{ define "widgets" }}


### PR DESCRIPTION
'Am here' isn't exactly grammatically correct. You would probably want 'I'm here' instead. But even that didn't seem so descriptive in terms of the action to be carried out by clicking the link. I think 'Take me home' might be a worthy alternative.